### PR TITLE
Remove telio.c

### DIFF
--- a/v6/telio.c
+++ b/v6/telio.c
@@ -1,8 +1,0 @@
-#include <telio.h>
-
-// This file exists beacause of
-// https://github.com/golang/go/issues/11263
-
-void cgo_rust_task_callback_bridge_telio(RustTaskCallback cb, const void * taskData, int8_t status) {
-  cb(taskData, status);
-}


### PR DESCRIPTION
As uniffi 0.28 no longer generates `.c` files, the presence of `telio.c` produces an error during the build:
```
# github.com/NordSecurity/libtelio-go/v6
telio.c:6:42: error: unknown type name 'RustTaskCallback'
    6 | void cgo_rust_task_callback_bridge_telio(RustTaskCallback cb, const void * taskData, int8_t status) {
      |     
```